### PR TITLE
feat: Adds statement creators for completed sale and generated lead (LLC-36)

### DIFF
--- a/src/examples/completedSale.ts
+++ b/src/examples/completedSale.ts
@@ -14,8 +14,7 @@ const statement = completedSale({
   isWon: true,
   closedReason: 'Too expensive',
   accountDisplayName: 'Example Account',
-  accountId: '456',
-  accountProviderUrl: 'https://demo.example.org',
+  accountUrl: 'https://demo.example.org',
 });
 
 export default statement;

--- a/src/examples/completedSale.ts
+++ b/src/examples/completedSale.ts
@@ -13,6 +13,9 @@ const statement = completedSale({
   userDisplayName: 'Demo User',
   isWon: true,
   closedReason: 'Too expensive',
+  accountDisplayName: 'Example Account',
+  accountId: '456',
+  accountProviderUrl: 'https://demo.example.org',
 });
 
 export default statement;

--- a/src/examples/completedSale.ts
+++ b/src/examples/completedSale.ts
@@ -1,0 +1,18 @@
+import completedSale from '../statementCreators/completedSale';
+
+const statement = completedSale({
+  actionDate: new Date(),
+  activityUrl: 'https://demo.example.org/courses/demo-course',
+  siteUrl: 'https://demo.example.org',
+  siteName: 'Demo Example Site',
+  platformUrl: 'https://example.org',
+  platformName: 'Example Platform',
+  userId: '123',
+  userIdProviderUrl: 'https://demo.example.org',
+  userEmail: 'demo@example.org',
+  userDisplayName: 'Demo User',
+  isWon: true,
+  closedReason: 'Too expensive',
+});
+
+export default statement;

--- a/src/examples/generatedLead.ts
+++ b/src/examples/generatedLead.ts
@@ -1,0 +1,16 @@
+import generatedLead from '../statementCreators/generatedLead';
+
+const statement = generatedLead({
+  actionDate: new Date(),
+  activityUrl: 'https://demo.example.org/courses/demo-course',
+  siteUrl: 'https://demo.example.org',
+  siteName: 'Demo Example Site',
+  platformUrl: 'https://example.org',
+  platformName: 'Example Platform',
+  userId: '123',
+  userIdProviderUrl: 'https://demo.example.org',
+  userEmail: 'demo@example.org',
+  userDisplayName: 'Demo User',
+});
+
+export default statement;

--- a/src/statementConstants/activityTypes.ts
+++ b/src/statementConstants/activityTypes.ts
@@ -173,6 +173,11 @@ export const resourceStructure = `${customBaseUrl}/resource-structure`;
 export const resourceStructureNode = `${customBaseUrl}/resource-structure-node`;
 
 /**
+ * Represents a sales opportunity.
+ */
+export const salesOpportunity = 'http://id.tincanapi.com/activitytype/sales-opportunity';
+
+/**
  * Represents a feature to enable admins to manage access on a per-user or per-group basis.
  */
 export const securityRole = 'http://id.tincanapi.com/activitytype/security-role';

--- a/src/statementConstants/activityTypes.ts
+++ b/src/statementConstants/activityTypes.ts
@@ -90,6 +90,11 @@ export const image = 'http://activitystrea.ms/schema/1.0/image';
 export const issue = 'http://activitystrea.ms/schema/1.0/issue';
 
 /**
+ * Represents a person or business who may eventually become a client
+ */
+export const salesLead = `${customBaseUrl}/sales-lead`;
+
+/**
  * Means of expressing a link to another resource within, or external to, an activity.
  * Not synonymous with launching another resource.
  * Should be considered external to the current resource.

--- a/src/statementConstants/verbs.ts
+++ b/src/statementConstants/verbs.ts
@@ -36,6 +36,10 @@ export const evaluated = createVerb('http://www.tincanapi.co.uk/verbs/evaluated'
 export const exited = createVerb('http://adlnet.gov/expapi/verbs/exited', 'exited');
 export const filled = createVerb('https://w3id.org/xapi/dod-isd/verbs/filled-out', 'filled');
 export const followed = createVerb('https://w3id.org/xapi/dod-isd/verbs/followed', 'followed');
+export const generated = createVerb(
+  'https://w3id.org/xapi/dod-isd/verbs/generated',
+  'generated a lead with',
+);
 export const joined = createVerb('http://activitystrea.ms/schema/1.0/join', 'joined');
 export const launched = createVerb('http://adlnet.gov/expapi/verbs/launched', 'launched');
 export const liked = createVerb('https://w3id.org/xapi/acrossx/verbs/liked', 'liked');

--- a/src/statementConstants/verbs.ts
+++ b/src/statementConstants/verbs.ts
@@ -21,6 +21,10 @@ export const attended = createVerb('http://activitystrea.ms/schema/1.0/attend', 
 export const bookmarked = createVerb('http://id.tincanapi.com/verb/bookmarked', 'bookmarked');
 export const called = createVerb('http://id.tincanapi.com/verb/called', 'called');
 export const canceled = createVerb('https://w3id.org/xapi/dod-isd/verbs/canceled', 'canceled');
+export const closedSale = createVerb(
+  'http://id.tincanapi.com/verb/closed-sale',
+  'closed a sale with',
+);
 export const commentedOn = createVerb('http://adlnet.gov/expapi/verbs/commented', 'commented on');
 export const completed = createVerb('http://adlnet.gov/expapi/verbs/completed', 'completed');
 export const created = createVerb('http://activitystrea.ms/schema/1.0/create', 'created');

--- a/src/statementCreators/completedSale.ts
+++ b/src/statementCreators/completedSale.ts
@@ -1,0 +1,67 @@
+import UserSiteAction from '../actionUtils/UserSiteAction';
+import { salesOpportunity, site, source } from '../statementConstants/activityTypes';
+import { closedSale } from '../statementConstants/verbs';
+import createActivity from '../statementUtils/createActivity';
+import createAgent from '../statementUtils/createAgent';
+import createTimestamp from '../statementUtils/createTimestamp';
+import { Extensions, Statement } from '../statementUtils/types';
+
+export interface CompletedSaleAction extends UserSiteAction {
+  /** The URL where the activity can be accessed. */
+  readonly activityUrl: string;
+
+  /** The human readable name for the activity. */
+  readonly activityName?: string;
+
+  /** Additional properties of the activity. */
+  readonly activityExtensions?: Extensions;
+
+  /** Determines if the sale was a success or failure. */
+  readonly isWon?: boolean;
+
+  /** The reason for which a sale or opportunity is closed, usually when lost */
+  readonly closedReason?: string;
+}
+
+/**
+ * Creates an xAPI Statement to represent a user completing a face-to-face meeting.
+ */
+export default function completedSale(action: CompletedSaleAction): Statement {
+  return {
+    timestamp: createTimestamp(action.actionDate),
+    actor: createAgent({
+      displayName: action.userDisplayName,
+      id: action.userId,
+      idProviderUrl: action.userIdProviderUrl,
+      email: action.userEmail,
+    }),
+    verb: closedSale,
+    object: createActivity({
+      type: salesOpportunity,
+      url: action.activityUrl,
+      name: action.activityName,
+      extensions: action.activityExtensions,
+    }),
+    context: {
+      platform: action.platformName,
+      language: 'en',
+      extensions: action.contextExtensions,
+      contextActivities: {
+        grouping: [createActivity({
+          type: site,
+          url: action.siteUrl,
+          name: action.siteName,
+        })],
+        category: [createActivity({
+          type: source,
+          url: action.platformUrl,
+          name: action.platformName,
+        })],
+      },
+    },
+    result: {
+      success: action.isWon,
+      response: action.closedReason,
+    },
+  };
+}

--- a/src/statementCreators/completedSale.ts
+++ b/src/statementCreators/completedSale.ts
@@ -21,6 +21,18 @@ export interface CompletedSaleAction extends UserSiteAction {
 
   /** The reason for which a sale or opportunity is closed, usually when lost */
   readonly closedReason?: string;
+
+  /** The name of the account linked to the sale or opportunity. */
+  readonly accountDisplayName?: string;
+
+  /** The unique identifier for the account. */
+  readonly accountId?: string;
+
+  /** The URL of the identity provider (e.g. https://ht2labs.com). Use siteUrl as fallback. */
+  readonly accountProviderUrl?: string;
+
+  /** An email address for the account (e.g. user@example.org). */
+  readonly accountEmail?: string;
 }
 
 /**
@@ -47,11 +59,19 @@ export default function completedSale(action: CompletedSaleAction): Statement {
       language: 'en',
       extensions: action.contextExtensions,
       contextActivities: {
-        grouping: [createActivity({
-          type: site,
-          url: action.siteUrl,
-          name: action.siteName,
-        })],
+        grouping: [
+          createActivity({
+            type: site,
+            url: action.siteUrl,
+            name: action.siteName,
+          }),
+          createAgent({
+            displayName: action.accountDisplayName,
+            id: action.accountId,
+            idProviderUrl: action.accountProviderUrl,
+            email: action.accountEmail,
+          }),
+        ],
         category: [createActivity({
           type: source,
           url: action.platformUrl,

--- a/src/statementCreators/completedSale.ts
+++ b/src/statementCreators/completedSale.ts
@@ -1,5 +1,5 @@
 import UserSiteAction from '../actionUtils/UserSiteAction';
-import { salesOpportunity, site, source } from '../statementConstants/activityTypes';
+import { organization, salesOpportunity, site, source } from '../statementConstants/activityTypes';
 import { closedSale } from '../statementConstants/verbs';
 import createActivity from '../statementUtils/createActivity';
 import createAgent from '../statementUtils/createAgent';
@@ -22,17 +22,11 @@ export interface CompletedSaleAction extends UserSiteAction {
   /** The reason for which a sale or opportunity is closed, usually when lost */
   readonly closedReason?: string;
 
-  /** The name of the account linked to the sale or opportunity. */
+  /** The URL or identifier of the account that owns the sale or opportunity. */
+  readonly accountUrl: string;
+
+  /** The name of the account that owns the sale or opportunity. */
   readonly accountDisplayName?: string;
-
-  /** The unique identifier for the account. */
-  readonly accountId?: string;
-
-  /** The URL of the identity provider (e.g. https://ht2labs.com). Use siteUrl as fallback. */
-  readonly accountProviderUrl?: string;
-
-  /** An email address for the account (e.g. user@example.org). */
-  readonly accountEmail?: string;
 }
 
 /**
@@ -65,11 +59,10 @@ export default function completedSale(action: CompletedSaleAction): Statement {
             url: action.siteUrl,
             name: action.siteName,
           }),
-          createAgent({
-            displayName: action.accountDisplayName,
-            id: action.accountId,
-            idProviderUrl: action.accountProviderUrl,
-            email: action.accountEmail,
+          createActivity({
+            type: organization,
+            url: action.accountUrl,
+            name: action.accountDisplayName,
           }),
         ],
         category: [createActivity({

--- a/src/statementCreators/completedSale.ts
+++ b/src/statementCreators/completedSale.ts
@@ -22,10 +22,10 @@ export interface CompletedSaleAction extends UserSiteAction {
   /** The reason for which a sale or opportunity is closed, usually when lost */
   readonly closedReason?: string;
 
-  /** The URL or identifier of the account that owns the sale or opportunity. */
+  /** The URL or identifier of the account or organization linked to the sale or opportunity. */
   readonly accountUrl: string;
 
-  /** The name of the account that owns the sale or opportunity. */
+  /** The name of the account or organization linked to the sale or opportunity. */
   readonly accountDisplayName?: string;
 }
 
@@ -59,6 +59,8 @@ export default function completedSale(action: CompletedSaleAction): Statement {
             url: action.siteUrl,
             name: action.siteName,
           }),
+        ],
+        parent: [
           createActivity({
             type: organization,
             url: action.accountUrl,

--- a/src/statementCreators/generatedLead.ts
+++ b/src/statementCreators/generatedLead.ts
@@ -1,0 +1,57 @@
+import UserSiteAction from '../actionUtils/UserSiteAction';
+import { salesLead, site, source } from '../statementConstants/activityTypes';
+import { generated } from '../statementConstants/verbs';
+import createActivity from '../statementUtils/createActivity';
+import createAgent from '../statementUtils/createAgent';
+import createTimestamp from '../statementUtils/createTimestamp';
+import { Extensions, Statement } from '../statementUtils/types';
+
+export interface GeneratedLeadAction extends UserSiteAction {
+  /** The URL where the activity can be accessed. */
+  readonly activityUrl: string;
+
+  /** The human readable name for the activity. */
+  readonly activityName?: string;
+
+  /** Additional properties of the activity. */
+  readonly activityExtensions?: Extensions;
+}
+
+/**
+ * Creates an xAPI Statement to represent a user completing a face-to-face meeting.
+ */
+export default function generatedLead(action: GeneratedLeadAction): Statement {
+  return {
+    timestamp: createTimestamp(action.actionDate),
+    actor: createAgent({
+      displayName: action.userDisplayName,
+      id: action.userId,
+      idProviderUrl: action.userIdProviderUrl,
+      email: action.userEmail,
+    }),
+    verb: generated,
+    object: createActivity({
+      type: salesLead,
+      url: action.activityUrl,
+      name: action.activityName,
+      extensions: action.activityExtensions,
+    }),
+    context: {
+      platform: action.platformName,
+      language: 'en',
+      extensions: action.contextExtensions,
+      contextActivities: {
+        grouping: [createActivity({
+          type: site,
+          url: action.siteUrl,
+          name: action.siteName,
+        })],
+        category: [createActivity({
+          type: source,
+          url: action.platformUrl,
+          name: action.platformName,
+        })],
+      },
+    },
+  };
+}

--- a/src/statementUtils/types.ts
+++ b/src/statementUtils/types.ts
@@ -147,7 +147,7 @@ export interface Context {
      * Activity with an indirect relation to the Activity which is the Object of the Statement.
      * Usually contains the site as an activity amongst other things.
      */
-    readonly grouping?: Activity[];
+    readonly grouping?: (Activity | Agent)[];
 
     /**
      * Activity that doesn't fit one of the other properties.

--- a/src/statementUtils/types.ts
+++ b/src/statementUtils/types.ts
@@ -147,7 +147,7 @@ export interface Context {
      * Activity with an indirect relation to the Activity which is the Object of the Statement.
      * Usually contains the site as an activity amongst other things.
      */
-    readonly grouping?: (Activity | Agent)[];
+    readonly grouping?: Activity[];
 
     /**
      * Activity that doesn't fit one of the other properties.


### PR DESCRIPTION
For use on [LLC-36](https://learningpool.atlassian.net/browse/LLC-36).

Used [this documentation](http://docs.learninglocker.net/guides-sales-statements/) as a guide.